### PR TITLE
Update dependencies and CI actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     container:
       image: ghcr.io/facet-rs/facet-ci:latest-amd64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: Swatinem/rust-cache@v2
 
@@ -47,7 +47,7 @@ jobs:
     container:
       image: ghcr.io/facet-rs/facet-ci:latest-amd64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: Swatinem/rust-cache@v2
 
@@ -68,7 +68,7 @@ jobs:
     container:
       image: ghcr.io/facet-rs/facet-ci:latest-amd64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: Swatinem/rust-cache@v2
 
@@ -92,7 +92,7 @@ jobs:
     container:
       image: ghcr.io/facet-rs/facet-ci:latest-amd64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: Swatinem/rust-cache@v2
 
@@ -111,7 +111,7 @@ jobs:
     container:
       image: ghcr.io/facet-rs/facet-ci:latest-amd64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: Swatinem/rust-cache@v2
 
@@ -128,7 +128,7 @@ jobs:
     permissions:
       security-events: write # to upload sarif results
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: Swatinem/rust-cache@v2
 
@@ -145,7 +145,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: clippy-results.sarif
           wait-for-processing: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,28 @@
 version = 4
 
 [[package]]
-name = "bitflags"
-version = "2.9.1"
+name = "allocator-api2"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "byteorder"
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "cargo-husky"
@@ -21,16 +33,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
 
 [[package]]
-name = "console"
-version = "0.15.11"
+name = "cfg-if"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "windows-sys",
 ]
+
+[[package]]
+name = "const-fnv1a-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
 
 [[package]]
 name = "encode_unicode"
@@ -39,23 +62,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "facet"
-version = "0.28.0"
+name = "equivalent"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3290e0be77e9eeca366489c3b4010764dc897a83e5936a93857c3937f47a57aa"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "facet"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ddcfe946b050b8aa99d2cf4e0b56e1437fcec41de190aebb9ff621d95b82157"
+dependencies = [
+ "autocfg",
  "facet-core",
  "facet-macros",
- "static_assertions",
 ]
 
 [[package]]
 name = "facet-core"
-version = "0.28.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8643770dc61323e6ae5620f336f4c4fc283a6bf39e6701fed32efa747fba5a6a"
+checksum = "b18251d9fd8e27c85ba879c75cb2f92fdd5f1e43c17fedc3a40faadcc3fa2a99"
 dependencies = [
- "bitflags",
+ "autocfg",
+ "const-fnv1a-hash",
+ "iddqd",
  "impls",
 ]
 
@@ -65,36 +106,25 @@ version = "0.23.23"
 dependencies = [
  "cargo-husky",
  "facet",
- "facet-core",
- "facet-macros",
  "insta",
 ]
 
 [[package]]
-name = "facet-macros"
-version = "0.28.0"
+name = "facet-macro-parse"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb526288148251e984f3a9ab3cef5191ca1da34a45fb5c548781e7053148e19"
+checksum = "b5f7d6b0fbbd7536883a30738d903e8aee8f76e7ee1a6ff8ea37cd16366a8e63"
 dependencies = [
- "facet-core",
- "facet-macros-emit",
-]
-
-[[package]]
-name = "facet-macros-emit"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52619b4834e81068fd915795c297e52f894a18742581627568d451e39dd1c906"
-dependencies = [
- "facet-macros-parse",
+ "facet-macro-types",
+ "proc-macro2",
  "quote",
 ]
 
 [[package]]
-name = "facet-macros-parse"
-version = "0.28.0"
+name = "facet-macro-types"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6097c15775794dd66eb69cd4614be654877e3e6e4a93ca0d0440236c1798f0b"
+checksum = "7121a5798fdc2e805121519e7c89be8e9a3e68460ac41ef3a3c83f7627713b79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -102,12 +132,106 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
+name = "facet-macros"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+checksum = "0c1db2d8fa23c6605ba449df4cd0f7426a6fcce1fc4f620052c4d5d1ffd57653"
 dependencies = [
- "byteorder",
+ "facet-macros-impl",
+]
+
+[[package]]
+name = "facet-macros-impl"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9853c5973e794ce3fc2d7cec37e2103264001ce351008a623959d434974ab6a"
+dependencies = [
+ "facet-macro-parse",
+ "facet-macro-types",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "unsynn",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "iddqd"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616230c7d641ef971a3a5bfcc654c6b7524ab9c9fb665693c6a397dba9a14aca"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "hashbrown 0.16.1",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -117,21 +241,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a46645bbd70538861a90d0f26c31537cdf1e44aae99a794fb75a664b70951bc"
 
 [[package]]
-name = "insta"
-version = "1.43.1"
+name = "indexmap"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
  "once_cell",
  "similar",
+ "tempfile",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.174"
+name = "itoa"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mutants"
@@ -141,33 +308,110 @@ checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "shadow_counted"
-version = "0.4.0"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65da48d447333cebe1aadbdd3662f3ba56e76e67f53bc46f3dd5f67c74629d6b"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
 
 [[package]]
 name = "similar"
@@ -176,98 +420,221 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
+name = "strsim"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsynn"
-version = "0.1.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940603a9e25cf11211cc43b81f4fcad2b8ab4df291ca855f32c40e1ac22d5bc"
+checksum = "501a7adf1a4bd9951501e5c66621e972ef8874d787628b7f90e64f936ef7ec0a"
 dependencies = [
- "fxhash",
  "mutants",
  "proc-macro2",
- "shadow_counted",
+ "rustc-hash",
 ]
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "wit-bindgen-rust-macro",
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
+name = "wit-bindgen"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
+name = "wit-bindgen-core"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
+name = "wit-bindgen-rust"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
 
 [[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
+name = "wit-component"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
+name = "wit-parser"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
+name = "zmij"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "facet-jsonschema"
 version = "0.23.23"
 edition = "2024"
-rust-version = "1.87"
+rust-version = "1.90"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/facet-rs/facet-jsonschema"
 description = "Generate JSON Schema from Facet types. Provides a `to_string` function to get a JSON Schema representation as a string. Useful for reflection, introspection, serialization, and deserialization."
@@ -16,10 +16,8 @@ keywords = [
 categories = ["development-tools", "encoding"]
 
 [dependencies]
-facet-core = { version = "0.28.0" }
-facet-macros = { version = "0.28.0" }
+facet = { version = "0.46.0" }
 
 [dev-dependencies]
-insta = "1.43.1"
-facet = { version = "0.28.0" }
+insta = "1.47.2"
 cargo-husky = { version = "1.5.0", default-features = false, features = ["user-hooks"] }

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ use facet_jsonschema::to_string;
 use facet::Facet;
 
 #[derive(Facet)]
+#[facet(facet_jsonschema::id = "https://example.com/test.schema.json")]
 struct TestStruct {
     /// String field
     string_field: String,

--- a/README.md.in
+++ b/README.md.in
@@ -10,6 +10,7 @@ use facet_jsonschema::to_string;
 use facet::Facet;
 
 #[derive(Facet)]
+#[facet(facet_jsonschema::id = "https://example.com/test.schema.json")]
 struct TestStruct {
     /// String field
     string_field: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,25 @@
 #![forbid(unsafe_code)]
 #![doc = include_str!("../README.md")]
 
-extern crate facet_core as facet;
-use facet::{PointerDef, PointerType, PrimitiveType, TextualType};
-use facet_core::{Def, Facet, Shape, Type, UserType};
+extern crate self as facet_jsonschema;
+
+use facet::{
+    Def, Facet, PointerDef, PointerType, PrimitiveType, Shape, TextualType, Type, UserType,
+};
 
 use core::alloc::Layout;
 use std::io::Write;
+
+facet::define_attr_grammar! {
+    ns "facet_jsonschema";
+    crate_path ::facet_jsonschema;
+
+    /// JSON Schema-specific Facet attributes.
+    pub enum Attr {
+        /// Sets the top-level JSON Schema `$id`.
+        Id(&'static str),
+    }
+}
 
 /// Convert a `Facet` type to a JSON schema string.
 pub fn to_string<'a, T: Facet<'a>>() -> String {
@@ -21,22 +34,12 @@ pub fn to_string<'a, T: Facet<'a>>() -> String {
     )
     .unwrap();
 
-    // Find the first attribute that starts with "id=", if it exists more than once is an error
-    let mut id = T::SHAPE.attributes.iter().filter_map(|attr| match attr {
-        facet_core::ShapeAttribute::Arbitrary(attr_str) => {
-            if attr_str.starts_with("id") {
-                let id = attr_str
-                    .split('=')
-                    .nth(1)
-                    .unwrap_or_default()
-                    .trim()
-                    .trim_matches('"');
-                Some(id)
-            } else {
-                None
-            }
-        }
-        _ => None,
+    // JSON Schema only allows a single top-level `$id`.
+    let mut id = T::SHAPE.attributes.iter().filter_map(|attr| {
+        (attr.ns == Some("facet_jsonschema") && attr.key == "id")
+            .then(|| attr.get_as::<&'static str>())
+            .flatten()
+            .copied()
     });
     match (id.next(), id.next()) {
         (Some(_), Some(_)) => panic!("More than one id attribute found"),
@@ -66,7 +69,7 @@ fn serialize<W: Write>(shape: &Shape, doc: &[&str], writer: &mut W) -> std::io::
             todo!("Enum");
         }
         Type::Sequence(sequence_type) => {
-            use facet_core::SequenceType;
+            use facet::SequenceType;
             match sequence_type {
                 SequenceType::Slice(_slice_type) => {
                     // For slices, use the Def::Slice if available
@@ -83,6 +86,10 @@ fn serialize<W: Write>(shape: &Shape, doc: &[&str], writer: &mut W) -> std::io::
                     }
                 }
             }
+        }
+        Type::Pointer(PointerType::Reference(pt) | PointerType::Raw(pt)) => {
+            serialize(pt.target(), &[], writer)?;
+            return Ok(());
         }
         _ => {} // Continue to check the def system
     }
@@ -115,13 +122,13 @@ fn serialize<W: Write>(shape: &Shape, doc: &[&str], writer: &mut W) -> std::io::
         Def::Pointer(PointerDef {
             pointee: Some(inner_shape),
             ..
-        }) => serialize(inner_shape(), &[], writer)?,
+        }) => serialize(inner_shape, &[], writer)?,
         Def::Undefined => {
             // Handle the case when not yet migrated to the Type enum
             // For primitives, we can try to infer the type
             match &shape.ty {
                 Type::Primitive(primitive) => {
-                    use facet_core::{NumericType, PrimitiveType, TextualType};
+                    use facet::{NumericType, PrimitiveType, TextualType};
                     match primitive {
                         PrimitiveType::Numeric(NumericType::Float) => {
                             write!(writer, "\"type\": \"number\", \"format\": \"double\"")?;
@@ -138,7 +145,7 @@ fn serialize<W: Write>(shape: &Shape, doc: &[&str], writer: &mut W) -> std::io::
                     }
                 }
                 Type::Pointer(PointerType::Reference(pt) | PointerType::Raw(pt)) => {
-                    serialize((pt.target)(), &[], writer)?
+                    serialize(pt.target(), &[], writer)?
                 }
                 _ => {
                     write!(writer, "\"type\": \"unknown\"")?;
@@ -164,10 +171,10 @@ fn serialize_doc<W: Write>(doc: &[&str], writer: &mut W) -> Result<(), std::io::
 /// Serialize a scalar definition to JSON schema format.
 fn serialize_scalar<W: Write>(
     layout: &Layout,
-    numeric_type: facet_core::NumericType,
+    numeric_type: facet::NumericType,
     writer: &mut W,
 ) -> std::io::Result<()> {
-    use facet_core::NumericType;
+    use facet::NumericType;
 
     match numeric_type {
         NumericType::Integer { signed } => {
@@ -189,7 +196,7 @@ fn serialize_scalar<W: Write>(
 }
 
 fn serialize_struct<W: Write>(
-    struct_type: &facet_core::StructType,
+    struct_type: &facet::StructType,
     writer: &mut W,
 ) -> std::io::Result<()> {
     write!(writer, "\"type\": \"object\",")?;
@@ -216,7 +223,7 @@ fn serialize_struct<W: Write>(
 }
 
 /// Serialize a list definition to JSON schema format.
-fn serialize_list<W: Write>(list_def: facet_core::ListDef, writer: &mut W) -> std::io::Result<()> {
+fn serialize_list<W: Write>(list_def: facet::ListDef, writer: &mut W) -> std::io::Result<()> {
     write!(writer, "\"type\": \"array\",")?;
     write!(writer, "\"items\": {{")?;
     serialize(list_def.t(), &[], writer)?;
@@ -225,10 +232,7 @@ fn serialize_list<W: Write>(list_def: facet_core::ListDef, writer: &mut W) -> st
 }
 
 /// Serialize a slice definition to JSON schema format.
-fn serialize_slice<W: Write>(
-    slice_def: facet_core::SliceDef,
-    writer: &mut W,
-) -> std::io::Result<()> {
+fn serialize_slice<W: Write>(slice_def: facet::SliceDef, writer: &mut W) -> std::io::Result<()> {
     write!(writer, "\"type\": \"array\",")?;
     write!(writer, "\"items\": {{")?;
     serialize(slice_def.t(), &[], writer)?;
@@ -237,10 +241,7 @@ fn serialize_slice<W: Write>(
 }
 
 /// Serialize an array definition to JSON schema format.
-fn serialize_array<W: Write>(
-    array_def: facet_core::ArrayDef,
-    writer: &mut W,
-) -> std::io::Result<()> {
+fn serialize_array<W: Write>(array_def: facet::ArrayDef, writer: &mut W) -> std::io::Result<()> {
     write!(writer, "\"type\": \"array\",")?;
     write!(writer, "\"minItems\": {},", array_def.n)?;
     write!(writer, "\"maxItems\": {},", array_def.n)?;
@@ -252,56 +253,9 @@ fn serialize_array<W: Write>(
 
 /// Serialize an option definition to JSON schema format.
 fn serialize_option<W: Write>(
-    _option_def: facet_core::OptionDef,
+    _option_def: facet::OptionDef,
     writer: &mut W,
 ) -> std::io::Result<()> {
     write!(writer, "\"type\": \"[]\",")?;
     unimplemented!("serialize_option");
-}
-
-#[cfg(test)]
-mod tests {
-    extern crate alloc;
-    use alloc::{rc::Rc, sync::Arc};
-
-    use super::*;
-    use facet_macros::Facet;
-    use insta::assert_snapshot;
-
-    #[test]
-    fn test_basic() {
-        /// Test documentation
-        #[derive(Facet)]
-        #[facet(id = "http://example.com/schema")]
-        struct TestStruct {
-            /// Test doc1
-            string_field: String,
-            /// Test doc2
-            int_field: u32,
-            vec_field: Vec<bool>,
-            slice_field: &'static [f64],
-            array_field: [f64; 3],
-        }
-
-        let schema = to_string::<TestStruct>();
-        assert_snapshot!(schema);
-    }
-
-    #[test]
-    fn test_pointers() {
-        /// Test documentation
-        #[derive(Facet)]
-        #[facet(id = "http://example.com/schema")]
-        struct TestStruct<'a> {
-            normal_pointer: &'a str,
-            box_pointer: Box<u32>,
-            arc: Arc<u32>,
-            rc: Rc<u32>,
-            #[allow(clippy::redundant_allocation)]
-            nested: Rc<&'a Arc<&'a *const u32>>,
-        }
-
-        let schema = to_string::<TestStruct>();
-        assert_snapshot!(schema);
-    }
 }

--- a/tests/jsonschema.rs
+++ b/tests/jsonschema.rs
@@ -1,0 +1,44 @@
+extern crate alloc;
+
+use alloc::{rc::Rc, sync::Arc};
+
+use facet::Facet;
+use facet_jsonschema::to_string;
+use insta::assert_snapshot;
+
+#[test]
+fn basic() {
+    /// Test documentation
+    #[derive(Facet)]
+    #[facet(facet_jsonschema::id = "http://example.com/schema")]
+    struct TestStruct {
+        /// Test doc1
+        string_field: String,
+        /// Test doc2
+        int_field: u32,
+        vec_field: Vec<bool>,
+        slice_field: &'static [f64],
+        array_field: [f64; 3],
+    }
+
+    let schema = to_string::<TestStruct>();
+    assert_snapshot!("basic", schema);
+}
+
+#[test]
+fn pointers() {
+    /// Test documentation
+    #[derive(Facet)]
+    #[facet(facet_jsonschema::id = "http://example.com/schema")]
+    struct TestStruct<'a> {
+        normal_pointer: &'a str,
+        box_pointer: Box<u32>,
+        arc: Arc<u32>,
+        rc: Rc<u32>,
+        #[allow(clippy::redundant_allocation)]
+        nested: Rc<&'a Arc<&'a *const u32>>,
+    }
+
+    let schema = to_string::<TestStruct>();
+    assert_snapshot!("pointers", schema);
+}

--- a/tests/snapshots/jsonschema__basic.snap
+++ b/tests/snapshots/jsonschema__basic.snap
@@ -1,5 +1,5 @@
 ---
-source: facet-jsonschema/src/lib.rs
+source: tests/jsonschema.rs
 expression: schema
 ---
 {"$schema": "https://json-schema.org/draft/2020-12/schema","$id": "http://example.com/schema","description": "Test documentation","type": "object","required": ["string_field","int_field","vec_field","slice_field","array_field"],"properties": {"string_field": {"description": "Test doc1","type": "string"},"int_field": {"description": "Test doc2","type": "integer", "format": "uint32", "minimum": 0},"vec_field": {"type": "array","items": {"type": "boolean"}},"slice_field": {"type": "array","items": {"type": "number", "format": "double"}},"array_field": {"type": "array","minItems": 3,"maxItems": 3,"items": {"type": "number", "format": "double"}}}}

--- a/tests/snapshots/jsonschema__pointers.snap
+++ b/tests/snapshots/jsonschema__pointers.snap
@@ -1,5 +1,5 @@
 ---
-source: facet-jsonschema/src/lib.rs
+source: tests/jsonschema.rs
 expression: schema
 ---
 {"$schema": "https://json-schema.org/draft/2020-12/schema","$id": "http://example.com/schema","description": "Test documentation","type": "object","required": ["normal_pointer","box_pointer","arc","rc","nested"],"properties": {"normal_pointer": {"type": "string"},"box_pointer": {"type": "integer", "format": "uint32", "minimum": 0},"arc": {"type": "integer", "format": "uint32", "minimum": 0},"rc": {"type": "integer", "format": "uint32", "minimum": 0},"nested": {"type": "integer", "format": "uint32", "minimum": 0}}}


### PR DESCRIPTION
## Summary

Bring `facet-jsonschema` up to date with the current Facet ecosystem and CI action versions.

## Changes

- Replace direct `facet-core`/`facet-macros` dependencies with `facet = 0.46.0`.
- Bump `insta` to `1.47.2` and refresh `Cargo.lock`.
- Raise MSRV to Rust `1.90`, matching the current Facet requirement.
- Add a `facet_jsonschema` extension attribute grammar with `#[facet(facet_jsonschema::id = "...")]` for JSON Schema `$id`.
- Move snapshot coverage to integration tests so namespaced attributes are exercised as downstream users will write them.
- Update workflow actions covered by existing Renovate PRs: `actions/checkout@v6` and `github/codeql-action/upload-sarif@v4`.
- Update README examples for the new namespaced `$id` attribute.

## Related open PRs reviewed

- Supersedes the dependency-only direction from #3, #4, #5, and #6 by combining the version bumps with the required Facet API migration.
- Includes the workflow action changes from #7 and #8.

## Test Plan

- `cargo fmt --check`
- `cargo clippy --all-features --all-targets --message-format=short -- -D warnings`
- `cargo nextest run`
- `cargo test --doc`
